### PR TITLE
Fix typo in ETL handbook

### DIFF
--- a/src/etl.md
+++ b/src/etl.md
@@ -89,7 +89,7 @@ The basic format is flat, but a slight nesting structure can also be used when p
 
 ## 3. Load
 
-As a general rule, preffered data format is **unpivoted tidy format (long format)**. In the case of Observable, this means a **flat (non-nested) JavaScript array**.
+As a general rule, preferred data format is **unpivoted tidy format (long format)**. In the case of Observable, this means a **flat (non-nested) JavaScript array**.
 
 Observable Plot recommends the long format, but the "wide format" with multiple series is also supported for some marks (such as lineY and areaY). Choose the appropriate format.
 


### PR DESCRIPTION
## Summary
- fix `preffered` typo in ETL handbook

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686823fd9cb4833082c68b7c321405e0